### PR TITLE
remove space in shinyproxy dockerfile

### DIFF
--- a/R/add_deploy_helpers.R
+++ b/R/add_deploy_helpers.R
@@ -206,7 +206,7 @@ add_dockerfile_shinyproxy <- function(
   
   dock$EXPOSE(3838)
   dock$CMD(glue::glue(
-    " [\"R\", \"-e\", \"options('shiny.port'=3838,shiny.host='0.0.0.0'); {read.dcf(path)[1]}::run_app()\"]"
+    " [\"R\", \"-e\", \"options('shiny.port'=3838,shiny.host='0.0.0.0');{read.dcf(path)[1]}::run_app()\"]"
   ))
   dock$write(output)
   


### PR DESCRIPTION
There were a white space in the CMD command in the shinyproxy dockerfile, between "options()" and "run_app()" call. The space make the argument be ignored when running the container.